### PR TITLE
Add basic in-memory search service

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -48,6 +48,8 @@ checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
 name = "blackbox"
 version = "0.1.0"
 dependencies = [
+ "serde",
+ "serde_json",
  "tokio",
  "warp",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,3 +6,5 @@ edition = "2024"
 [dependencies]
 warp = "0.3"
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # BlackBox Hello World App
 
-This project provides a minimal HTTP server written in Rust using the [`warp`](https://crates.io/crates/warp) framework. The server responds with `Hello world` on the root path. All previous JavaScript code has been removed, so no Node.js setup is required.
+This project provides a minimal HTTP server written in Rust using the [`warp`](https://crates.io/crates/warp) framework. The server responds with `Hello world` on the root path and includes a very small in-memory search index. All previous JavaScript code has been removed, so no Node.js setup is required.
 
 ## Building and Running
 
@@ -13,3 +13,26 @@ cargo run
 The server listens on port `3000` by default. Set the `PORT` environment variable to change the port.
 
 Visit `http://localhost:3000/` to see the message.
+
+## API
+
+### Add a document
+
+```
+POST /documents
+Content-Type: application/json
+{
+  "title": "Example",
+  "body": "Some text to index"
+}
+```
+
+The response contains the assigned document `id`.
+
+### Search documents
+
+```
+GET /search?q=term
+```
+
+Returns a JSON array of matching documents with their ids.

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,17 @@
+use std::sync::Arc;
+use tokio::sync::RwLock;
 use warp::Filter;
+use serde::{Deserialize, Serialize};
+use serde_json::{json, Value};
+
+#[derive(Clone, Serialize, Deserialize)]
+struct Document {
+    id: usize,
+    #[serde(flatten)]
+    data: Value,
+}
+
+type Documents = Arc<RwLock<Vec<Document>>>;
 
 #[tokio::main]
 async fn main() {
@@ -7,9 +20,56 @@ async fn main() {
         .and_then(|s| s.parse().ok())
         .unwrap_or(3000);
 
+    let docs: Documents = Arc::new(RwLock::new(Vec::new()));
+    let docs_filter = warp::any().map(move || docs.clone());
+
     // Route that returns "Hello world" on the root path
     let hello = warp::path::end().map(|| "Hello world");
 
+    let add_document = warp::path("documents")
+        .and(warp::post())
+        .and(warp::body::json())
+        .and(docs_filter.clone())
+        .and_then(add_document);
+
+    let search = warp::path("search")
+        .and(warp::get())
+        .and(warp::query::<SearchQuery>())
+        .and(docs_filter)
+        .and_then(search_documents);
+
+    let routes = hello.or(add_document).or(search);
+
     println!("Server running on port {}", port);
-    warp::serve(hello).run(([0, 0, 0, 0], port)).await;
+    warp::serve(routes).run(([0, 0, 0, 0], port)).await;
+}
+
+#[derive(Deserialize)]
+struct SearchQuery {
+    q: String,
+}
+
+async fn add_document(doc: Value, docs: Documents) -> Result<impl warp::Reply, warp::Rejection> {
+    let mut list = docs.write().await;
+    let id = list.len() + 1;
+    list.push(Document { id, data: doc });
+    Ok(warp::reply::json(&json!({ "id": id })))
+}
+
+async fn search_documents(params: SearchQuery, docs: Documents) -> Result<impl warp::Reply, warp::Rejection> {
+    let list = docs.read().await;
+    let query = params.q.to_lowercase();
+    let results: Vec<_> = list
+        .iter()
+        .filter(|d| serialize_contains(&d.data, &query))
+        .map(|d| json!({ "id": d.id, "document": d.data }))
+        .collect();
+    Ok(warp::reply::json(&results))
+}
+
+fn serialize_contains(value: &Value, query: &str) -> bool {
+    value
+        .to_string()
+        .to_lowercase()
+        .contains(query)
 }


### PR DESCRIPTION
## Summary
- expand server with in-memory document index
- allow POST `/documents` to store JSON docs
- allow GET `/search?q=...` to search stored docs
- document new API in README

## Testing
- `cargo build`
- `cargo run -q` & curl POST `/documents` then GET `/search`


------
https://chatgpt.com/codex/tasks/task_e_68402aca4e708329a98c65073a551b39