### PR TITLE
Add vector search capability

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -164,6 +164,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serial_test",
+ "strsim",
  "tokio",
  "warp",
 ]
@@ -1532,6 +1533,12 @@ name = "stable_deref_trait"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
+
+[[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "syn"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "alloc-no-stdlib"
 version = "2.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -30,6 +39,56 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94fb8275041c72129eb51b7d0322c29b8387a0386127718b096429201a5d6ece"
 dependencies = [
  "alloc-no-stdlib",
+]
+
+[[package]]
+name = "anstream"
+version = "0.6.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "301af1932e46185686725e0fad2f8f2aa7da69dd70bf6ecc44d6b703844a3933"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "862ed96ca487e809f1c8e5a8447f6ee2cf102f846893800b20cebdf541fc6bbd"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c8bdeb6047d8983be085bab0ba1472e6dc604e7041dbf6fcd5e71523014fae9"
+dependencies = [
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "403f75924867bb1033c59fbf0797484329750cfbe3c4325cd33127941fabc882"
+dependencies = [
+ "anstyle",
+ "once_cell_polyfill",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -99,9 +158,12 @@ name = "blackbox"
 version = "0.1.0"
 dependencies = [
  "bincode",
+ "env_logger",
+ "log",
  "reqwest",
  "serde",
  "serde_json",
+ "serial_test",
  "tokio",
  "warp",
 ]
@@ -170,6 +232,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "colorchoice"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
+
+[[package]]
 name = "core-foundation"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -214,6 +282,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "dashmap"
+version = "5.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "978747c1d849a7d2ee5e8adc0159961c48fb7e5db2f06af6723b80123bb53856"
+dependencies = [
+ "cfg-if",
+ "hashbrown 0.14.5",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core",
+]
+
+[[package]]
 name = "data-encoding"
 version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -247,6 +328,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "env_filter"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "186e05a59d4c50738528153b83b0b0194d3a29507dfec16eccd4b342903397d0"
+dependencies = [
+ "log",
+ "regex",
+]
+
+[[package]]
+name = "env_logger"
+version = "0.11.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c863f0904021b108aa8b2f55046443e6b1ebde8fd4a15c399893aae4fa069f"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "env_filter",
+ "jiff",
+ "log",
 ]
 
 [[package]]
@@ -312,6 +416,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
 name = "futures-channel"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -326,6 +445,23 @@ name = "futures-core"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e28d1d997f585e54aebc3f97d39e72338912123a67330d723fdbb564d646c9f"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-io"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
 
 [[package]]
 name = "futures-sink"
@@ -345,9 +481,12 @@ version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
 dependencies = [
+ "futures-channel",
  "futures-core",
+ "futures-io",
  "futures-sink",
  "futures-task",
+ "memchr",
  "pin-project-lite",
  "pin-utils",
  "slab",
@@ -410,6 +549,12 @@ dependencies = [
  "tokio-util",
  "tracing",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 
 [[package]]
 name = "hashbrown"
@@ -651,7 +796,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cea70ddb795996207ad57735b50c5982d8844f38ba9ee5f1aedcfb708a2aa11e"
 dependencies = [
  "equivalent",
- "hashbrown",
+ "hashbrown 0.15.3",
 ]
 
 [[package]]
@@ -661,10 +806,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
 
 [[package]]
+name = "is_terminal_polyfill"
+version = "1.70.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
+
+[[package]]
 name = "itoa"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
+
+[[package]]
+name = "jiff"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a194df1107f33c79f4f93d02c80798520551949d59dfad22b6157048a88cca93"
+dependencies = [
+ "jiff-static",
+ "log",
+ "portable-atomic",
+ "portable-atomic-util",
+ "serde",
+]
+
+[[package]]
+name = "jiff-static"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c6e1db7ed32c6c71b759497fae34bf7933636f75a251b9e736555da426f6442"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "js-sys"
@@ -675,6 +850,12 @@ dependencies = [
  "once_cell",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
@@ -693,6 +874,16 @@ name = "litemap"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "241eaef5fd12c88705a01fc1066c48c4b36e0dd4377dcdc7ec3942cea7a69956"
+
+[[package]]
+name = "lock_api"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96936507f153605bddfcda068dd804796c84324ed2510809e5b2a624c81da765"
+dependencies = [
+ "autocfg",
+ "scopeguard",
+]
 
 [[package]]
 name = "log"
@@ -793,6 +984,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
+name = "once_cell_polyfill"
+version = "1.70.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4895175b425cb1f87721b59f0f286c2092bd4af812243672510e1ac53e2e0ad"
+
+[[package]]
 name = "openssl"
 version = "0.10.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -834,6 +1031,29 @@ dependencies = [
  "libc",
  "pkg-config",
  "vcpkg",
+]
+
+[[package]]
+name = "parking_lot"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70d58bf43669b5795d1576d0641cfb6fbb2057bf629506267a92807158584a13"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc838d2a56b5b1a6c25f55575dfc605fabb63bb2365f6c2353ef9159aa69e4a5"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -879,6 +1099,21 @@ name = "pkg-config"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+
+[[package]]
+name = "portable-atomic"
+version = "1.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f84267b20a16ea918e43c6a88433c2d54fa145c92a811b5b047ccbe153674483"
+
+[[package]]
+name = "portable-atomic-util"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8a2f0d8d040d7848a709caf78912debcc3f33ee4b3cac47d73d1e1069e83507"
+dependencies = [
+ "portable-atomic",
+]
 
 [[package]]
 name = "potential_utf"
@@ -951,6 +1186,44 @@ checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom 0.2.16",
 ]
+
+[[package]]
+name = "redox_syscall"
+version = "0.5.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "928fca9cf2aa042393a8325b9ead81d2f0df4cb12e1e24cef072922ccd99c5af"
+dependencies = [
+ "bitflags 2.9.1",
+]
+
+[[package]]
+name = "regex"
+version = "1.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "reqwest"
@@ -1090,6 +1363,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294"
 
 [[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
 name = "sct"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1164,6 +1443,31 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "serial_test"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e56dd856803e253c8f298af3f4d7eb0ae5e23a737252cd90bb4f3b435033b2d"
+dependencies = [
+ "dashmap",
+ "futures",
+ "lazy_static",
+ "log",
+ "parking_lot",
+ "serial_test_derive",
+]
+
+[[package]]
+name = "serial_test_derive"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91d129178576168c589c9ec973feedf7d3126c01ac2bf08795109aa35b69fb8f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1491,6 +1795,12 @@ name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "vcpkg"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -64,7 +64,7 @@ dependencies = [
  "miniz_oxide",
  "object",
  "rustc-demangle",
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -83,10 +83,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bitflags"
+version = "2.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b8e56985ec62d17e9c1001dc89c88ecd7dc08e47eba5ec7c29c7b5eeecde967"
+
+[[package]]
 name = "blackbox"
 version = "0.1.0"
 dependencies = [
  "bincode",
+ "reqwest",
  "serde",
  "serde_json",
  "tokio",
@@ -124,6 +137,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "bumpalo"
+version = "3.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "793db76d6187cd04dff33004d8e6c9cc4e05cd330500379d2394209271b4aeee"
+
+[[package]]
 name = "byteorder"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -136,10 +155,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
 
 [[package]]
+name = "cc"
+version = "1.2.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "956a5e21988b87f372569b66183b78babf23ebc2e744b733e4350a752c4dafac"
+dependencies = [
+ "shlex",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "core-foundation"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "cpufeatures"
@@ -212,6 +256,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
+name = "errno"
+version = "0.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cea14ef9355e3beab063703aa9dab15afd25f0667c341310c1e5274bb1d0da18"
+dependencies = [
+ "libc",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "fastrand"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
 name = "flate2"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -226,6 +286,21 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "form_urlencoded"
@@ -296,7 +371,19 @@ checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26145e563e54f2cadc477553f1ec5ee650b00862f0a58bcd12cbdc5f0ea2d2f4"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "wasi 0.14.2+wasi-0.2.4",
 ]
 
 [[package]]
@@ -424,6 +511,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-rustls"
+version = "0.24.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec3efd23720e2049821a693cbc7e65ea87c72f1c58ff2f9522ff332b1491e590"
+dependencies = [
+ "futures-util",
+ "http 0.2.12",
+ "hyper",
+ "rustls",
+ "tokio",
+ "tokio-rustls",
+]
+
+[[package]]
+name = "hyper-tls"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
+dependencies = [
+ "bytes",
+ "hyper",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
+]
+
+[[package]]
 name = "icu_collections"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -541,16 +655,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "ipnet"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
+
+[[package]]
 name = "itoa"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
+name = "js-sys"
+version = "0.3.77"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cfaf33c695fc6e08064efbc1f72ec937429614f25eef83af942d0e227c3a28f"
+dependencies = [
+ "once_cell",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "libc"
 version = "0.2.172"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d750af042f7ef4f724306de029d18836c26c1765a54a6a3f094cbd23a7267ffa"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12"
 
 [[package]]
 name = "litemap"
@@ -602,7 +738,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78bed444cc8a2160f01cbcf811ef18cac863ad68ae8ca62092e8db51d51c761c"
 dependencies = [
  "libc",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
  "windows-sys 0.59.0",
 ]
 
@@ -625,6 +761,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "native-tls"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87de3442987e9dbec73158d5c715e7ad9072fda936bb03d19d7fa10e00520f0e"
+dependencies = [
+ "libc",
+ "log",
+ "openssl",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "security-framework",
+ "security-framework-sys",
+ "tempfile",
+]
+
+[[package]]
 name = "object"
 version = "0.36.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -638,6 +791,50 @@ name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+
+[[package]]
+name = "openssl"
+version = "0.10.73"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8505734d46c8ab1e19a1dce3aef597ad87dcb4c37e7188231769bd6bd51cebf8"
+dependencies = [
+ "bitflags 2.9.1",
+ "cfg-if",
+ "foreign-types",
+ "libc",
+ "once_cell",
+ "openssl-macros",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "openssl-probe"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.109"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90096e2e47630d78b7d1c20952dc621f957103f8bc2c8359ec81290d75238571"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
 
 [[package]]
 name = "percent-encoding"
@@ -678,6 +875,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
+name = "pkg-config"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+
+[[package]]
 name = "potential_utf"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -714,6 +917,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "r-efi"
+version = "5.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74765f6d916ee2faa39bc8e68e4f3ed8949b48cccdac59983d287a7cb71ce9c5"
+
+[[package]]
 name = "rand"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -740,7 +949,67 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.16",
+]
+
+[[package]]
+name = "reqwest"
+version = "0.11.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd67538700a17451e7cba03ac727fb961abb7607553461627b97de0b89cf4a62"
+dependencies = [
+ "async-compression",
+ "base64",
+ "bytes",
+ "encoding_rs",
+ "futures-core",
+ "futures-util",
+ "h2",
+ "http 0.2.12",
+ "http-body",
+ "hyper",
+ "hyper-rustls",
+ "hyper-tls",
+ "ipnet",
+ "js-sys",
+ "log",
+ "mime",
+ "native-tls",
+ "once_cell",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustls",
+ "rustls-pemfile",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "system-configuration",
+ "tokio",
+ "tokio-native-tls",
+ "tokio-rustls",
+ "tokio-util",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "webpki-roots",
+ "winreg",
+]
+
+[[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.16",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -750,16 +1019,108 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
 
 [[package]]
+name = "rustix"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c71e83d6afe7ff64890ec6b71d6a69bb8a610ab78ce364b3352876bb4c801266"
+dependencies = [
+ "bitflags 2.9.1",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "rustls"
+version = "0.21.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f56a14d1f48b391359b22f731fd4bd7e43c97f3c50eee276f3aa09c94784d3e"
+dependencies = [
+ "log",
+ "ring",
+ "rustls-webpki",
+ "sct",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c74cae0a4cf6ccbbf5f359f08efdf8ee7e1dc532573bf0db71968cb56b1448c"
+dependencies = [
+ "base64",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.101.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
+dependencies = [
+ "ring",
+ "untrusted",
+]
+
+[[package]]
+name = "rustversion"
+version = "1.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a0d197bd2c9dc6e53b84da9556a69ba4cdfab8619eb41a8bd1cc2027a0f6b1d"
+
+[[package]]
 name = "ryu"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
 
 [[package]]
+name = "schannel"
+version = "0.1.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f29ebaa345f945cec9fbbc532eb307f0fdad8161f281b6369539c8d84876b3d"
+dependencies = [
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "scoped-tls"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294"
+
+[[package]]
+name = "sct"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414"
+dependencies = [
+ "ring",
+ "untrusted",
+]
+
+[[package]]
+name = "security-framework"
+version = "2.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
+dependencies = [
+ "bitflags 2.9.1",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49db231d56a190491cb4aeda9527f1ad45345af50b0851622a7adb8c03b01c32"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
 
 [[package]]
 name = "serde"
@@ -817,6 +1178,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "signal-hook-registry"
+version = "1.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9203b8055f63a2a00e2f593bb0510367fe707d7ff1e5c872de2f537b339e5410"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "slab"
 version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -865,6 +1241,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "sync_wrapper"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
+
+[[package]]
 name = "synstructure"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -873,6 +1255,40 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "system-configuration"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba3a3adc5c275d719af8cb4272ea1c4a6d668a777f37e115f6d11ddbc1c8e0e7"
+dependencies = [
+ "bitflags 1.3.2",
+ "core-foundation",
+ "system-configuration-sys",
+]
+
+[[package]]
+name = "system-configuration-sys"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75fb188eb626b924683e3b95e3a48e63551fcfb51949de2f06a9d91dbee93c9"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8a64e3985349f2441a1a9ef0b853f869006c3855f2cda6862a94d26ebb9d6a1"
+dependencies = [
+ "fastrand",
+ "getrandom 0.3.3",
+ "once_cell",
+ "rustix",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -916,6 +1332,7 @@ dependencies = [
  "libc",
  "mio",
  "pin-project-lite",
+ "signal-hook-registry",
  "socket2",
  "tokio-macros",
  "windows-sys 0.52.0",
@@ -930,6 +1347,26 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "tokio-native-tls"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
+dependencies = [
+ "native-tls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
+dependencies = [
+ "rustls",
+ "tokio",
 ]
 
 [[package]]
@@ -1027,6 +1464,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
 
 [[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
 name = "url"
 version = "2.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1048,6 +1491,12 @@ name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version_check"
@@ -1101,12 +1550,117 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
+name = "wasi"
+version = "0.14.2+wasi-0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9683f9a5a998d873c0d21fcbe3c083009670149a8fab228644b8bd36b2c48cb3"
+dependencies = [
+ "wit-bindgen-rt",
+]
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1edc8929d7499fc4e8f0be2262a241556cfc54a0bea223790e71446f2aab1ef5"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "rustversion",
+ "wasm-bindgen-macro",
+]
+
+[[package]]
+name = "wasm-bindgen-backend"
+version = "0.2.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f0a0651a5c2bc21487bde11ee802ccaf4c51935d0d3d42a6101f98161700bc6"
+dependencies = [
+ "bumpalo",
+ "log",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.50"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "555d470ec0bc3bb57890405e5d4322cc9ea83cebb085523ced7be4144dac1e61"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "once_cell",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fe63fc6d09ed3792bd0897b314f53de8e16568c2b3f7982f468c0bf9bd0b407"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-backend",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "web-sys"
+version = "0.3.77"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33b6dd2ef9186f1f2072e409e99cd22a975331a6b3591b12c764e0e55c60d5d2"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "0.25.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f20c57d8d7db6d3b86154206ae5d8fba62dd39573114de97c2cb0578251f8e1"
+
+[[package]]
+name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets 0.48.5",
+]
+
+[[package]]
 name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -1115,7 +1669,22 @@ version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+dependencies = [
+ "windows_aarch64_gnullvm 0.48.5",
+ "windows_aarch64_msvc 0.48.5",
+ "windows_i686_gnu 0.48.5",
+ "windows_i686_msvc 0.48.5",
+ "windows_x86_64_gnu 0.48.5",
+ "windows_x86_64_gnullvm 0.48.5",
+ "windows_x86_64_msvc 0.48.5",
 ]
 
 [[package]]
@@ -1124,15 +1693,21 @@ version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
  "windows_i686_gnullvm",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
 ]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
@@ -1142,9 +1717,21 @@ checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -1160,9 +1747,21 @@ checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -1172,15 +1771,46 @@ checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
 name = "windows_x86_64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
+
+[[package]]
+name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "winreg"
+version = "0.50.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "524e57b2c537c0f9b1e69f1965311ec12182b4122e45035b1508cd24d2adadb1"
+dependencies = [
+ "cfg-if",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "wit-bindgen-rt"
+version = "0.39.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
+dependencies = [
+ "bitflags 2.9.1",
+]
 
 [[package]]
 name = "writeable"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,9 @@ tokio = { version = "1", features = ["macros", "rt-multi-thread", "process"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 bincode = "1"
+log = "0.4"
+env_logger = "0.11"
 
 [dev-dependencies]
 reqwest = { version = "0.11", features = ["json", "rustls-tls", "gzip"] }
+serial_test = "2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,10 @@ edition = "2024"
 
 [dependencies]
 warp = { version = "0.3", features = ["compression"] }
-tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
+tokio = { version = "1", features = ["macros", "rt-multi-thread", "process"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 bincode = "1"
+
+[dev-dependencies]
+reqwest = { version = "0.11", features = ["json", "rustls-tls", "gzip"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ serde_json = "1"
 bincode = "1"
 log = "0.4"
 env_logger = "0.11"
+strsim = "0.11"
 
 [dev-dependencies]
 reqwest = { version = "0.11", features = ["json", "rustls-tls", "gzip"] }

--- a/README.md
+++ b/README.md
@@ -24,6 +24,30 @@ Content-Type: application/json
 
 Creates the index if it does not exist and returns the assigned document `id`.
 
+### Bulk indexing
+
+```bash
+POST /indexes/<index>/bulk
+Content-Type: application/json
+{
+  "documents": [ {"title": "a"}, {"title": "b"} ]
+}
+```
+
+Allows multiple documents to be indexed in a single request.
+
+### Set field mapping
+
+```bash
+PUT /indexes/<index>/mapping
+Content-Type: application/json
+{
+  "fields": { "title": "string", "views": "numeric", "vector": "vector" }
+}
+```
+
+Defines simple field types for an index.
+
 ### Search documents
 
 ```
@@ -31,6 +55,36 @@ GET /indexes/<index>/search?q=term
 ```
 
 Returns an array of documents whose serialized JSON contains the query string.
+
+### Query DSL
+
+```bash
+POST /indexes/<index>/query
+Content-Type: application/json
+{
+  "term": { "title": "test" },
+  "sort": { "field": "views", "order": "desc" },
+  "aggs": "category"
+}
+```
+
+Supports simple term and range filters with optional sorting and basic count aggregation.
+
+### Search by vector
+
+```bash
+POST /indexes/<index>/search_vector
+Content-Type: application/json
+{
+  "vector": [0.1, 0.2, 0.3],
+  "k": 5,
+  "field": "vector"
+}
+```
+
+Documents may include an optional array field storing a vector embedding. The
+`/search_vector` endpoint returns the `k` nearest documents based on L2 distance
+using the specified vector field.
 
 ## Data Storage
 

--- a/README.md
+++ b/README.md
@@ -56,6 +56,16 @@ GET /indexes/<index>/search?q=term
 
 Returns an array of documents whose serialized JSON contains the query string.
 
+Optional query parameters:
+
+```
+GET /indexes/<index>/search?q=term&limit=5&fuzz=1&scores=true
+```
+
+`limit` controls the number of hits returned, `fuzz` applies a simple
+Levenshtein distance for matches, and `scores` includes a `score` field in the
+results.
+
 ### Query DSL
 
 ```bash
@@ -77,14 +87,15 @@ POST /indexes/<index>/search_vector
 Content-Type: application/json
 {
   "vector": [0.1, 0.2, 0.3],
-  "k": 5,
+  "limit": 5,
   "field": "vector"
 }
 ```
 
 Documents may include an optional array field storing a vector embedding. The
-`/search_vector` endpoint returns the `k` nearest documents based on L2 distance
-using the specified vector field.
+`/search_vector` endpoint returns the nearest documents based on L2 distance
+using the specified vector field. Set `scores` to `true` to include the distance
+value with each hit.
 
 ## Data Storage
 

--- a/src/index.rs
+++ b/src/index.rs
@@ -1,0 +1,38 @@
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use std::collections::HashMap;
+
+#[derive(Clone, Serialize, Deserialize)]
+pub struct Document {
+    pub id: usize,
+    #[serde(skip)]
+    pub vector: Option<Vec<f32>>,
+    #[serde(flatten)]
+    pub data: Value,
+}
+
+#[derive(Clone, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "lowercase")]
+pub enum FieldType {
+    String,
+    Numeric,
+    Vector,
+}
+
+#[derive(Clone, Serialize, Deserialize, Default)]
+pub struct Mapping {
+    pub fields: HashMap<String, FieldType>,
+}
+
+#[derive(Default, Clone, Serialize, Deserialize)]
+pub struct Index {
+    pub docs: Vec<Document>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub mapping: Option<Mapping>,
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct PersistedDocument {
+    pub id: usize,
+    pub data: Vec<u8>,
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,15 +1,17 @@
+use serde::{Deserialize, Serialize};
+use serde_json::{Value, json};
 use std::collections::HashMap;
 use std::path::PathBuf;
 use std::sync::Arc;
 use tokio::fs;
 use tokio::sync::RwLock;
 use warp::{Filter, Rejection, Reply};
-use serde::{Deserialize, Serialize};
-use serde_json::{json, Value};
 
 #[derive(Clone, Serialize, Deserialize)]
 struct Document {
     id: usize,
+    #[serde(skip)]
+    vector: Option<Vec<f32>>,
     #[serde(flatten)]
     data: Value,
 }
@@ -51,9 +53,16 @@ async fn main() {
         .and(indexes_filter.clone())
         .and_then(search_documents);
 
+    let search_vector = warp::path!("indexes" / String / "search_vector")
+        .and(warp::post())
+        .and(warp::body::json())
+        .and(indexes_filter.clone())
+        .and_then(search_vector);
+
     let routes = hello
         .or(add_document)
         .or(search)
+        .or(search_vector)
         .with(warp::compression::gzip());
 
     println!("Server running on port {}", port);
@@ -65,11 +74,29 @@ struct SearchQuery {
     q: String,
 }
 
-async fn add_document(index: String, doc: Value, indexes: Indexes) -> Result<impl Reply, Rejection> {
+#[derive(Deserialize)]
+struct VectorQuery {
+    vector: Vec<f32>,
+    #[serde(default)]
+    k: Option<usize>,
+    #[serde(default)]
+    field: Option<String>,
+}
+
+async fn add_document(
+    index: String,
+    doc: Value,
+    indexes: Indexes,
+) -> Result<impl Reply, Rejection> {
     let mut map = indexes.write().await;
     let entry = map.entry(index.clone()).or_default();
     let id = entry.docs.len() + 1;
-    entry.docs.push(Document { id, data: doc });
+    let vector = extract_vector(&doc, "vector");
+    entry.docs.push(Document {
+        id,
+        vector,
+        data: doc,
+    });
 
     if let Err(e) = persist_index(&index, &entry.docs).await {
         eprintln!("failed to save index {index}: {e}");
@@ -79,7 +106,11 @@ async fn add_document(index: String, doc: Value, indexes: Indexes) -> Result<imp
     Ok(warp::reply::json(&json!({ "id": id })))
 }
 
-async fn search_documents(index: String, params: SearchQuery, indexes: Indexes) -> Result<impl Reply, Rejection> {
+async fn search_documents(
+    index: String,
+    params: SearchQuery,
+    indexes: Indexes,
+) -> Result<impl Reply, Rejection> {
     let map = indexes.read().await;
     if let Some(idx) = map.get(&index) {
         let query = params.q.to_lowercase();
@@ -101,11 +132,77 @@ async fn search_documents(index: String, params: SearchQuery, indexes: Indexes) 
     }
 }
 
+async fn search_vector(
+    index: String,
+    query: VectorQuery,
+    indexes: Indexes,
+) -> Result<impl Reply, Rejection> {
+    let map = indexes.read().await;
+    if let Some(idx) = map.get(&index) {
+        let k = query.k.unwrap_or(10);
+        let field = query.field.unwrap_or_else(|| "vector".to_string());
+        let qvec = query.vector;
+
+        let mut scored: Vec<(usize, f32)> = idx
+            .docs
+            .iter()
+            .filter_map(|d| {
+                let extracted;
+                let vec = if field == "vector" {
+                    d.vector.as_ref()
+                } else {
+                    extracted = extract_vector(&d.data, &field);
+                    extracted.as_ref()
+                }?;
+                Some((d.id, l2_distance(&qvec, vec)))
+            })
+            .collect();
+
+        scored.sort_by(|a, b| a.1.partial_cmp(&b.1).unwrap_or(std::cmp::Ordering::Equal));
+        let results: Vec<_> = scored
+            .into_iter()
+            .take(k)
+            .filter_map(|(id, _)| {
+                idx.docs
+                    .iter()
+                    .find(|doc| doc.id == id)
+                    .map(|doc| json!({ "id": doc.id, "document": doc.data }))
+            })
+            .collect();
+        Ok(warp::reply::with_status(
+            warp::reply::json(&results),
+            warp::http::StatusCode::OK,
+        ))
+    } else {
+        Ok(warp::reply::with_status(
+            warp::reply::json(&json!({"error": "index not found"})),
+            warp::http::StatusCode::NOT_FOUND,
+        ))
+    }
+}
+
 fn serialize_contains(value: &Value, query: &str) -> bool {
-    value
-        .to_string()
-        .to_lowercase()
-        .contains(query)
+    value.to_string().to_lowercase().contains(query)
+}
+
+fn extract_vector(data: &Value, field: &str) -> Option<Vec<f32>> {
+    data.get(field)?.as_array().map(|arr| {
+        arr.iter()
+            .filter_map(|v| v.as_f64().map(|f| f as f32))
+            .collect()
+    })
+}
+
+fn l2_distance(a: &[f32], b: &[f32]) -> f32 {
+    if a.len() != b.len() {
+        f32::INFINITY
+    } else {
+        a.iter()
+            .zip(b)
+            .map(|(x, y)| (x - y).powi(2))
+            .sum::<f32>()
+            .sqrt()
+    }
 }
 
 async fn load_indexes() -> Indexes {
@@ -130,9 +227,14 @@ async fn load_indexes() -> Indexes {
                         let docs = raw_docs
                             .into_iter()
                             .filter_map(|d| {
-                                serde_json::from_slice(&d.data)
-                                    .ok()
-                                    .map(|value| Document { id: d.id, data: value })
+                                serde_json::from_slice(&d.data).ok().map(|value| {
+                                    let vector = extract_vector(&value, "vector");
+                                    Document {
+                                        id: d.id,
+                                        vector,
+                                        data: value,
+                                    }
+                                })
                             })
                             .collect();
                         map.insert(name.to_string(), Index { docs });
@@ -155,7 +257,7 @@ async fn persist_index(name: &str, docs: &Vec<Document>) -> Result<(), std::io::
                 .map(|data| PersistedDocument { id: d.id, data })
         })
         .collect();
-    let bytes = bincode::serialize(&raw)
-        .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))?;
+    let bytes =
+        bincode::serialize(&raw).map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))?;
     fs::write(path, bytes).await
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,36 +1,57 @@
 mod index;
-mod utils;
 mod storage;
+mod utils;
 
 use crate::index::{Document, Mapping};
-use crate::utils::{extract_vector, l2_distance, serialize_contains};
 use crate::storage::{Indexes, load_indexes, persist_index, persist_mapping};
+use crate::utils::{extract_vector, fuzzy_match, l2_distance, serialize_contains};
 use env_logger;
 use serde::Deserialize;
-use serde_json::{json, Value};
-use warp::{Filter, Rejection, Reply};
+use serde_json::{Value, json};
 use std::cmp::Ordering;
+use warp::{Filter, Rejection, Reply};
 
 #[derive(Deserialize)]
-struct SearchQuery { q: String }
+struct SearchQuery {
+    q: String,
+    #[serde(default)]
+    limit: Option<usize>,
+    #[serde(default)]
+    fuzz: Option<usize>,
+    #[serde(default)]
+    scores: Option<bool>,
+}
 
 #[derive(Deserialize)]
 struct VectorQuery {
     vector: Vec<f32>,
-    #[serde(default)]
-    k: Option<usize>,
+    #[serde(default, alias = "k")]
+    limit: Option<usize>,
     #[serde(default)]
     field: Option<String>,
+    #[serde(default)]
+    scores: Option<bool>,
 }
 
 #[derive(Deserialize)]
-struct BulkDocs { documents: Vec<Value> }
+struct BulkDocs {
+    documents: Vec<Value>,
+}
 
 #[derive(Deserialize)]
-struct DslRange { #[serde(default)] gte: Option<f64>, #[serde(default)] lte: Option<f64> }
+struct DslRange {
+    #[serde(default)]
+    gte: Option<f64>,
+    #[serde(default)]
+    lte: Option<f64>,
+}
 
 #[derive(Deserialize)]
-struct DslSort { field: String, #[serde(default)] order: Option<String> }
+struct DslSort {
+    field: String,
+    #[serde(default)]
+    order: Option<String>,
+}
 
 #[derive(Deserialize)]
 struct DslQuery {
@@ -42,12 +63,21 @@ struct DslQuery {
     sort: Option<DslSort>,
     #[serde(default)]
     aggs: Option<String>,
+    #[serde(default)]
+    limit: Option<usize>,
+    #[serde(default)]
+    fuzz: Option<usize>,
+    #[serde(default)]
+    scores: Option<bool>,
 }
 
 #[tokio::main]
 async fn main() {
     env_logger::init();
-    let port: u16 = std::env::var("PORT").ok().and_then(|s| s.parse().ok()).unwrap_or(3000);
+    let port: u16 = std::env::var("PORT")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(3000);
 
     let indexes = load_indexes().await;
     let indexes_filter = warp::any().map(move || indexes.clone());
@@ -90,6 +120,23 @@ async fn main() {
         .and(indexes_filter.clone())
         .and_then(search_vector);
 
+    let metrics = warp::log::custom(|info| {
+        let latency = info.elapsed().as_millis();
+        let len = info
+            .request_headers()
+            .get("content-length")
+            .and_then(|v| v.to_str().ok())
+            .unwrap_or("0");
+        log::info!(
+            "{} {} -> {} {}ms req={}b",
+            info.method(),
+            info.path(),
+            info.status().as_u16(),
+            latency,
+            len
+        );
+    });
+
     let routes = hello
         .or(add_document)
         .or(bulk_docs)
@@ -98,18 +145,26 @@ async fn main() {
         .or(search_dsl)
         .or(search_vector)
         .with(warp::compression::gzip())
-        .with(warp::log("blackbox"));
+        .with(metrics);
 
     println!("Server running on port {}", port);
     warp::serve(routes).run(([0, 0, 0, 0], port)).await;
 }
 
-async fn add_document(index: String, doc: Value, indexes: Indexes) -> Result<impl Reply, Rejection> {
+async fn add_document(
+    index: String,
+    doc: Value,
+    indexes: Indexes,
+) -> Result<impl Reply, Rejection> {
     let id = insert_doc(&index, doc, indexes, true).await?;
     Ok(warp::reply::json(&json!({"id": id})))
 }
 
-async fn bulk_documents(index: String, bulk: BulkDocs, indexes: Indexes) -> Result<impl Reply, Rejection> {
+async fn bulk_documents(
+    index: String,
+    bulk: BulkDocs,
+    indexes: Indexes,
+) -> Result<impl Reply, Rejection> {
     let mut ids = Vec::new();
     for doc in bulk.documents {
         if let Ok(id) = insert_doc(&index, doc, indexes.clone(), false).await {
@@ -119,12 +174,21 @@ async fn bulk_documents(index: String, bulk: BulkDocs, indexes: Indexes) -> Resu
     Ok(warp::reply::json(&json!({"ids": ids})))
 }
 
-async fn insert_doc(index: &str, doc: Value, indexes: Indexes, persist: bool) -> Result<usize, Rejection> {
+async fn insert_doc(
+    index: &str,
+    doc: Value,
+    indexes: Indexes,
+    persist: bool,
+) -> Result<usize, Rejection> {
     let mut map = indexes.write().await;
     let entry = map.entry(index.to_string()).or_default();
     let id = entry.docs.len() + 1;
     let vector = extract_vector(&doc, "vector");
-    entry.docs.push(Document { id, vector, data: doc });
+    entry.docs.push(Document {
+        id,
+        vector,
+        data: doc,
+    });
     if persist {
         if let Err(e) = persist_index(index, entry).await {
             eprintln!("failed to save index {index}: {e}");
@@ -134,7 +198,11 @@ async fn insert_doc(index: &str, doc: Value, indexes: Indexes, persist: bool) ->
     Ok(id)
 }
 
-async fn set_mapping(index: String, mapping: Mapping, indexes: Indexes) -> Result<impl Reply, Rejection> {
+async fn set_mapping(
+    index: String,
+    mapping: Mapping,
+    indexes: Indexes,
+) -> Result<impl Reply, Rejection> {
     let mut map = indexes.write().await;
     let entry = map.entry(index.clone()).or_default();
     entry.mapping = Some(mapping.clone());
@@ -144,30 +212,67 @@ async fn set_mapping(index: String, mapping: Mapping, indexes: Indexes) -> Resul
     Ok(warp::reply::json(&json!({"status": "ok"})))
 }
 
-async fn search_documents(index: String, params: SearchQuery, indexes: Indexes) -> Result<impl Reply, Rejection> {
+async fn search_documents(
+    index: String,
+    params: SearchQuery,
+    indexes: Indexes,
+) -> Result<impl Reply, Rejection> {
     let map = indexes.read().await;
     if let Some(idx) = map.get(&index) {
+        let limit = params.limit.unwrap_or(10);
+        let fuzz = params.fuzz.unwrap_or(0);
+        let include_scores = params.scores.unwrap_or(false);
         let query = params.q.to_lowercase();
-        let results: Vec<_> = idx
+        let mut scored: Vec<(usize, f32)> = idx
             .docs
             .iter()
-            .filter(|d| serialize_contains(&d.data, &query))
-            .map(|d| json!({ "id": d.id, "document": d.data }))
+            .filter_map(|d| {
+                if fuzz > 0 {
+                    fuzzy_match(&d.data, &query, fuzz).map(|dist| (d.id, 1.0 / (dist as f32 + 1.0)))
+                } else if serialize_contains(&d.data, &query) {
+                    Some((d.id, 1.0))
+                } else {
+                    None
+                }
+            })
             .collect();
-        Ok(warp::reply::json(&results))
+        scored.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(Ordering::Equal));
+        let results: Vec<_> = scored
+            .into_iter()
+            .take(limit)
+            .filter_map(|(id, score)| {
+                idx.docs.iter().find(|doc| doc.id == id).map(|doc| {
+                    if include_scores {
+                        json!({ "id": doc.id, "document": doc.data, "score": score })
+                    } else {
+                        json!({ "id": doc.id, "document": doc.data })
+                    }
+                })
+            })
+            .collect();
+        Ok(warp::reply::json(&json!({"hits": results})))
     } else {
         Ok(warp::reply::json(&json!({"error": "index not found"})))
     }
 }
 
-async fn search_dsl(index: String, req: DslQuery, indexes: Indexes) -> Result<impl Reply, Rejection> {
+async fn search_dsl(
+    index: String,
+    req: DslQuery,
+    indexes: Indexes,
+) -> Result<impl Reply, Rejection> {
     use std::collections::HashMap;
     let map = indexes.read().await;
     if let Some(idx) = map.get(&index) {
         let mut results: Vec<&Document> = idx.docs.iter().collect();
-        if let Some(term) = req.term {
+        if let Some(ref term) = req.term {
             for (field, value) in term {
-                results.retain(|d| d.data.get(&field).map(|v| v == &Value::String(value.clone())).unwrap_or(false));
+                results.retain(|d| {
+                    d.data
+                        .get(&field)
+                        .map(|v| v == &Value::String(value.clone()))
+                        .unwrap_or(false)
+                });
             }
         }
         if let Some(range) = req.range {
@@ -175,15 +280,45 @@ async fn search_dsl(index: String, req: DslQuery, indexes: Indexes) -> Result<im
                 results.retain(|d| {
                     if let Some(v) = d.data.get(&field).and_then(|v| v.as_f64()) {
                         flt.gte.map_or(true, |g| v >= g) && flt.lte.map_or(true, |l| v <= l)
-                    } else { false }
+                    } else {
+                        false
+                    }
                 });
             }
         }
         if let Some(sort) = req.sort {
             results.sort_by(|a, b| compare_vals(a.data.get(&sort.field), b.data.get(&sort.field)));
-            if sort.order.as_deref() == Some("desc") { results.reverse(); }
+            if sort.order.as_deref() == Some("desc") {
+                results.reverse();
+            }
         }
-        let hits: Vec<_> = results.iter().map(|d| json!({"id": d.id, "document": d.data })).collect();
+
+        let limit = req.limit.unwrap_or(results.len());
+        let fuzz = req.fuzz.unwrap_or(0);
+        let include_scores = req.scores.unwrap_or(false);
+        let mut hits = Vec::new();
+        for d in results.iter().take(limit) {
+            let score = if fuzz > 0 {
+                req.term
+                    .as_ref()
+                    .and_then(|m| {
+                        m.iter().next().and_then(|(field, val)| {
+                            d.data
+                                .get(field)
+                                .and_then(|v| fuzzy_match(v, val, fuzz))
+                                .map(|dist| 1.0 / (dist as f32 + 1.0))
+                        })
+                    })
+                    .unwrap_or(1.0)
+            } else {
+                1.0
+            };
+            if include_scores {
+                hits.push(json!({"id": d.id, "document": d.data, "score": score}));
+            } else {
+                hits.push(json!({"id": d.id, "document": d.data}));
+            }
+        }
         let mut body = json!({"hits": hits});
         if let Some(field) = req.aggs {
             let mut counts: HashMap<String, usize> = HashMap::new();
@@ -202,17 +337,25 @@ async fn search_dsl(index: String, req: DslQuery, indexes: Indexes) -> Result<im
 
 fn compare_vals(a: Option<&Value>, b: Option<&Value>) -> Ordering {
     match (a, b) {
-        (Some(Value::Number(na)), Some(Value::Number(nb))) => na.as_f64().partial_cmp(&nb.as_f64()).unwrap_or(Ordering::Equal),
+        (Some(Value::Number(na)), Some(Value::Number(nb))) => na
+            .as_f64()
+            .partial_cmp(&nb.as_f64())
+            .unwrap_or(Ordering::Equal),
         (Some(Value::String(sa)), Some(Value::String(sb))) => sa.cmp(sb),
         _ => Ordering::Equal,
     }
 }
 
-async fn search_vector(index: String, query: VectorQuery, indexes: Indexes) -> Result<impl Reply, Rejection> {
+async fn search_vector(
+    index: String,
+    query: VectorQuery,
+    indexes: Indexes,
+) -> Result<impl Reply, Rejection> {
     let map = indexes.read().await;
     if let Some(idx) = map.get(&index) {
-        let k = query.k.unwrap_or(10);
+        let limit = query.limit.unwrap_or(10);
         let field = query.field.unwrap_or_else(|| "vector".to_string());
+        let include_scores = query.scores.unwrap_or(false);
         let qvec = query.vector;
         let mut scored: Vec<(usize, f32)> = idx
             .docs
@@ -229,10 +372,20 @@ async fn search_vector(index: String, query: VectorQuery, indexes: Indexes) -> R
             })
             .collect();
         scored.sort_by(|a, b| a.1.partial_cmp(&b.1).unwrap_or(Ordering::Equal));
-        let results: Vec<_> = scored.into_iter().take(k).filter_map(|(id, _)| {
-            idx.docs.iter().find(|doc| doc.id == id).map(|doc| json!({ "id": doc.id, "document": doc.data }))
-        }).collect();
-        Ok(warp::reply::json(&results))
+        let results: Vec<_> = scored
+            .into_iter()
+            .take(limit)
+            .filter_map(|(id, distance)| {
+                idx.docs.iter().find(|doc| doc.id == id).map(|doc| {
+                    if include_scores {
+                        json!({ "id": doc.id, "document": doc.data, "score": distance })
+                    } else {
+                        json!({ "id": doc.id, "document": doc.data })
+                    }
+                })
+            })
+            .collect();
+        Ok(warp::reply::json(&json!({"hits": results})))
     } else {
         Ok(warp::reply::json(&json!({"error": "index not found"})))
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,6 +5,7 @@ mod storage;
 use crate::index::{Document, Mapping};
 use crate::utils::{extract_vector, l2_distance, serialize_contains};
 use crate::storage::{Indexes, load_indexes, persist_index, persist_mapping};
+use env_logger;
 use serde::Deserialize;
 use serde_json::{json, Value};
 use warp::{Filter, Rejection, Reply};
@@ -45,6 +46,7 @@ struct DslQuery {
 
 #[tokio::main]
 async fn main() {
+    env_logger::init();
     let port: u16 = std::env::var("PORT").ok().and_then(|s| s.parse().ok()).unwrap_or(3000);
 
     let indexes = load_indexes().await;
@@ -95,7 +97,8 @@ async fn main() {
         .or(search)
         .or(search_dsl)
         .or(search_vector)
-        .with(warp::compression::gzip());
+        .with(warp::compression::gzip())
+        .with(warp::log("blackbox"));
 
     println!("Server running on port {}", port);
     warp::serve(routes).run(([0, 0, 0, 0], port)).await;

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -1,4 +1,4 @@
-use crate::index::{Document, PersistedDocument, Index, Mapping};
+use crate::index::{Document, Index, Mapping, PersistedDocument};
 use crate::utils::extract_vector;
 use std::collections::HashMap;
 use std::path::PathBuf;
@@ -32,7 +32,11 @@ pub async fn load_indexes() -> Indexes {
                             .filter_map(|d| {
                                 serde_json::from_slice(&d.data).ok().map(|value| {
                                     let vector = extract_vector(&value, "vector");
-                                    Document { id: d.id, vector, data: value }
+                                    Document {
+                                        id: d.id,
+                                        vector,
+                                        data: value,
+                                    }
                                 })
                             })
                             .collect();
@@ -58,7 +62,8 @@ pub async fn persist_index(name: &str, index: &Index) -> Result<(), std::io::Err
                 .map(|data| PersistedDocument { id: d.id, data })
         })
         .collect();
-    let bytes = bincode::serialize(&raw).map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))?;
+    let bytes =
+        bincode::serialize(&raw).map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))?;
     fs::write(path, bytes).await
 }
 
@@ -72,6 +77,7 @@ pub async fn load_mapping(name: &str) -> Option<Mapping> {
 
 pub async fn persist_mapping(name: &str, mapping: &Mapping) -> Result<(), std::io::Error> {
     let path = PathBuf::from("data").join(format!("{name}.mapping.json"));
-    let bytes = serde_json::to_vec(mapping).map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))?;
+    let bytes = serde_json::to_vec(mapping)
+        .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))?;
     fs::write(path, bytes).await
 }

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -1,0 +1,77 @@
+use crate::index::{Document, PersistedDocument, Index, Mapping};
+use crate::utils::extract_vector;
+use std::collections::HashMap;
+use std::path::PathBuf;
+use std::sync::Arc;
+use tokio::fs;
+use tokio::sync::RwLock;
+
+pub type Indexes = Arc<RwLock<HashMap<String, Index>>>;
+
+pub async fn load_indexes() -> Indexes {
+    let mut map = HashMap::new();
+    let data_dir = PathBuf::from("data");
+    if let Err(e) = fs::create_dir_all(&data_dir).await {
+        eprintln!("failed to create data dir: {e}");
+        return Arc::new(RwLock::new(map));
+    }
+
+    let mut entries = match fs::read_dir(&data_dir).await {
+        Ok(e) => e,
+        Err(_) => return Arc::new(RwLock::new(map)),
+    };
+
+    while let Ok(Some(entry)) = entries.next_entry().await {
+        let path = entry.path();
+        if path.extension().and_then(|s| s.to_str()) == Some("bin") {
+            if let Ok(content) = fs::read(&path).await {
+                if let Ok(raw_docs) = bincode::deserialize::<Vec<PersistedDocument>>(&content) {
+                    if let Some(name) = path.file_stem().and_then(|s| s.to_str()) {
+                        let docs = raw_docs
+                            .into_iter()
+                            .filter_map(|d| {
+                                serde_json::from_slice(&d.data).ok().map(|value| {
+                                    let vector = extract_vector(&value, "vector");
+                                    Document { id: d.id, vector, data: value }
+                                })
+                            })
+                            .collect();
+                        let mapping = load_mapping(name).await;
+                        map.insert(name.to_string(), Index { docs, mapping });
+                    }
+                }
+            }
+        }
+    }
+
+    Arc::new(RwLock::new(map))
+}
+
+pub async fn persist_index(name: &str, index: &Index) -> Result<(), std::io::Error> {
+    let path = PathBuf::from("data").join(format!("{name}.bin"));
+    let raw: Vec<PersistedDocument> = index
+        .docs
+        .iter()
+        .filter_map(|d| {
+            serde_json::to_vec(&d.data)
+                .ok()
+                .map(|data| PersistedDocument { id: d.id, data })
+        })
+        .collect();
+    let bytes = bincode::serialize(&raw).map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))?;
+    fs::write(path, bytes).await
+}
+
+pub async fn load_mapping(name: &str) -> Option<Mapping> {
+    let path = PathBuf::from("data").join(format!("{name}.mapping.json"));
+    match fs::read(&path).await {
+        Ok(bytes) => serde_json::from_slice(&bytes).ok(),
+        Err(_) => None,
+    }
+}
+
+pub async fn persist_mapping(name: &str, mapping: &Mapping) -> Result<(), std::io::Error> {
+    let path = PathBuf::from("data").join(format!("{name}.mapping.json"));
+    let bytes = serde_json::to_vec(mapping).map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))?;
+    fs::write(path, bytes).await
+}

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,0 +1,25 @@
+use serde_json::Value;
+
+pub fn serialize_contains(value: &Value, query: &str) -> bool {
+    value.to_string().to_lowercase().contains(query)
+}
+
+pub fn extract_vector(data: &Value, field: &str) -> Option<Vec<f32>> {
+    data.get(field)?.as_array().map(|arr| {
+        arr.iter()
+            .filter_map(|v| v.as_f64().map(|f| f as f32))
+            .collect()
+    })
+}
+
+pub fn l2_distance(a: &[f32], b: &[f32]) -> f32 {
+    if a.len() != b.len() {
+        f32::INFINITY
+    } else {
+        a.iter()
+            .zip(b)
+            .map(|(x, y)| (x - y).powi(2))
+            .sum::<f32>()
+            .sqrt()
+    }
+}

--- a/tests/api.rs
+++ b/tests/api.rs
@@ -1,0 +1,138 @@
+use reqwest::Client;
+use serde_json::json;
+use std::process::{Command, Stdio};
+use tokio::time::{Duration, sleep};
+
+fn spawn_server(port: u16) -> std::process::Child {
+    let exe = env!("CARGO_BIN_EXE_blackbox");
+    Command::new(exe)
+        .env("PORT", port.to_string())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("failed to spawn server")
+}
+
+fn cleanup() {
+    let _ = std::fs::remove_dir_all("data");
+}
+async fn wait_for(port: u16) {
+    let client = Client::new();
+    for _ in 0..20u8 {
+        if let Ok(resp) = client.get(&format!("http://localhost:{port}")).send().await {
+            if resp.status().is_success() {
+                break;
+            }
+        }
+        sleep(Duration::from_millis(100)).await;
+    }
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_add_and_search() {
+    cleanup();
+    let port = 4101u16;
+    let mut srv = spawn_server(port);
+    wait_for(port).await;
+    let client = Client::new();
+    let index = "testidx1";
+    let doc = json!({"title": "hello world", "vector": [1.0, 0.0]});
+    client
+        .post(&format!(
+            "http://localhost:{port}/indexes/{index}/documents"
+        ))
+        .json(&doc)
+        .send()
+        .await
+        .unwrap();
+
+    let resp = client
+        .get(&format!(
+            "http://localhost:{port}/indexes/{index}/search?q=hello"
+        ))
+        .send()
+        .await
+        .unwrap();
+    let body = resp.text().await.unwrap();
+    println!("search body: {}", body);
+    let res: Vec<serde_json::Value> = serde_json::from_str(&body).unwrap();
+    assert_eq!(res.len(), 1);
+    srv.kill().unwrap();
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_bulk_and_dsl() {
+    cleanup();
+    let port = 4102u16;
+    let mut srv = spawn_server(port);
+    wait_for(port).await;
+    let client = Client::new();
+    let index = "testidx2";
+    let bulk = json!({"documents": [
+        {"title": "a", "views": 10},
+        {"title": "b", "views": 20},
+        {"title": "c", "views": 15}
+    ]});
+    client
+        .post(&format!("http://localhost:{port}/indexes/{index}/bulk"))
+        .json(&bulk)
+        .send()
+        .await
+        .unwrap();
+
+    let query = json!({
+        "range": {"views": {"gte": 15.0}},
+        "sort": {"field": "views", "order": "desc"}
+    });
+    let resp = client
+        .post(&format!("http://localhost:{port}/indexes/{index}/query"))
+        .json(&query)
+        .send()
+        .await
+        .unwrap();
+    let body = resp.text().await.unwrap();
+    println!("dsl body: {}", body);
+    let res: serde_json::Value = serde_json::from_str(&body).unwrap();
+    let hits = res["hits"].as_array().unwrap();
+    assert_eq!(hits.len(), 2);
+    assert!(
+        hits[0]["document"]["views"].as_i64().unwrap()
+            >= hits[1]["document"]["views"].as_i64().unwrap()
+    );
+    srv.kill().unwrap();
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_vector_search() {
+    cleanup();
+    let port = 4103u16;
+    let mut srv = spawn_server(port);
+    wait_for(port).await;
+    let client = Client::new();
+    let index = "testidx3";
+    let docs = json!({"documents": [
+        {"title": "a", "vector": [0.0, 1.0]},
+        {"title": "b", "vector": [1.0, 0.0]}
+    ]});
+    client
+        .post(&format!("http://localhost:{port}/indexes/{index}/bulk"))
+        .json(&docs)
+        .send()
+        .await
+        .unwrap();
+    let body = json!({"vector": [0.9, 0.1], "k": 1});
+    let resp = client
+        .post(&format!(
+            "http://localhost:{port}/indexes/{index}/search_vector"
+        ))
+        .json(&body)
+        .send()
+        .await
+        .unwrap();
+    let btext = resp.text().await.unwrap();
+    println!("vector body: {}", btext);
+    let res: Vec<serde_json::Value> = serde_json::from_str(&btext).unwrap();
+    assert_eq!(res.len(), 1);
+    assert_eq!(res[0]["document"]["title"], "b");
+    srv.kill().unwrap();
+}


### PR DESCRIPTION
## Summary
- embed optional vectors within documents
- parse vectors when loading and adding documents
- add `/search_vector` endpoint for similarity search
- implement helper functions for vector extraction and distance

## Testing
- `cargo build`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_6844a30a23e48329bb2ec3d983028baa